### PR TITLE
Fetch quickstarts

### DIFF
--- a/webapp/blaster/conductor.py
+++ b/webapp/blaster/conductor.py
@@ -84,7 +84,9 @@ def list_nodes(name=None):
 
     db = get_db()
     db_res = db.execute('SELECT url, auth_key FROM conductor WHERE name = ?', (name,)).fetchone()
-    nodes, error = get_all_nodes(name, db_res['url'], db_res['auth_key'])
+    nodes, error = get_all_nodes(name, db_res[0], db_res[1])
+    print("Test123")
+    print(nodes)
     if nodes:
         return render_template('conductor_list_nodes.html', nodes=nodes, conductor=name)
 
@@ -121,6 +123,15 @@ def get_quickstart(conductor=None, router=None, node=None, assetId=None):
         flash("A required parameter (conductor, router, or node) was not specified")
         return redirect(url_for('conductor.menu'))
 
+    success, error = get_quickstart_work(conductor, router, node, assetId)
+    if not success:
+        flash(error)
+        return redirect(url_for('conductor.list'))
+
+    flash(f"Added quickstart data returned from conductor {conductor} for router {router} node {node}")
+    return redirect(url_for('conductor.list'))
+
+def get_quickstart_work(conductor, router, node, assetId):
     db = get_db()
     conductor_data = db.execute('SELECT url, auth_key FROM conductor WHERE name = ?', (conductor,)).fetchone()
 
@@ -142,12 +153,12 @@ def get_quickstart(conductor=None, router=None, node=None, assetId=None):
     try:
         qs_resp = requests.post(qs_url, headers=headers, data=json.dumps(node_data), verify=False)
     except requests.exceptions.Timeout:
-        flash(f"Timeout connecting to conductor {name}")
-        return redirect(url_for('conductor.menu'))
+        error = f"Timeout connecting to conductor {name}"
+        return False, error
 
     if not qs_resp.ok:
-        flash(f"Conductor {name} returned error for quickstart query {qs_resp.status_code}: {qs_resp.json()}")
-        return redirect(url_for('conductor.menu'))
+        error = f"Conductor {name} returned error for quickstart query {qs_resp.status_code}: {qs_resp.json()}"
+        return False, error
 
     try:
         qs_json = qs_resp.json()
@@ -155,7 +166,8 @@ def get_quickstart(conductor=None, router=None, node=None, assetId=None):
         qs_asset = qs_json['a']
         qs_config = qs_json['c']
 
-        db.execute('INSERT INTO quickstart (' \
+        cursor = db.cursor()
+        cursor.execute('INSERT INTO quickstart (' \
                        'conductor_name, ' \
                        'router_name, ' \
                        'node_name, ' \
@@ -163,10 +175,10 @@ def get_quickstart(conductor=None, router=None, node=None, assetId=None):
                        'config, ' \
                        'description) VALUES (?, ?, ?, ?, ?, ?)',
            (conductor, router, qs_node, qs_asset, qs_config, 'Retrieved by blaster'))
+        qs_id = cursor.lastrowid
         db.commit()
     except KeyError:
-        flash(f"Error parsing quickstart data returned from conductor {conductor} for router {router} node {node}")
-        return redirect(url_for('conductor.menu'))
+        error = f"Error parsing quickstart data returned from conductor {conductor} for router {router} node {node}"
+        return False, error
 
-    flash(f"Added quickstart data returned from conductor {conductor} for router {router} node {node}")
-    return redirect(url_for('conductor.list'))
+    return True, qs_id

--- a/webapp/blaster/node.py
+++ b/webapp/blaster/node.py
@@ -4,6 +4,7 @@ from flask import (
     current_app, Blueprint, flash, Flask, g, redirect, render_template, request, session, url_for, jsonify
 )
 
+from blaster.conductor import get_all_nodes, get_quickstart_work
 from blaster.db import get_db
 from blaster.iso import get_active
 
@@ -62,11 +63,46 @@ def associate():
             flash("Both a quickstart and node identifier must be selected")
             return redirect(request.url)
 
-        db.execute('UPDATE node SET quickstart_id = ? WHERE identifier = ?', (qs_id, identifier))
-        db.commit()
+        associate_quickstart_to_node(qs_id, identifier)
         flash(f"made quickstart association for node with identifier of {identifier}")
         return redirect(request.url)
 
     quickstarts = db.execute('SELECT id, conductor_name, node_name, router_name FROM quickstart').fetchall()
     nodes = db.execute('SELECT identifier, quickstart_id from node').fetchall()
     return render_template('node_quickstart_associate.html', quickstarts=quickstarts, nodes=nodes)
+
+def associate_quickstart_to_node(qs_id, identifier):
+    db = get_db()
+    db.execute('UPDATE node SET quickstart_id = ? WHERE identifier = ?', (qs_id, identifier))
+    db.commit()
+
+@bp.route('/fetch', methods=('POST',))
+def fetch():
+    db = get_db()
+    blasted_nodes = db.execute('SELECT id, identifier FROM node WHERE status = "Blasted" and quickstart_id is null').fetchall()
+    blasted_list = []
+    for node in blasted_nodes:
+        blasted_list.append(node[1])
+
+    conductors = db.execute('SELECT name, url, auth_key FROM conductor').fetchall()
+    errors = []
+    for conductor in conductors:
+        nodes, error = get_all_nodes(conductor[0], conductor[1], conductor[2])
+        if error:
+            errors.append(error)
+            continue
+
+        for node in nodes:
+            if node['assetId'] in blasted_list:
+                router_name = node['router']['name']
+                node_name = node['name']
+                assetId = node['assetId']
+                success, qs_id_or_error = get_quickstart_work(conductor[0], router_name, node_name, assetId)
+                if success:
+                    associate_quickstart_to_node(qs_id_or_error, assetId)
+
+                else:
+                    errors.append(qs_id_or_error)
+
+    flash('\n'.join(errors))
+    return redirect(url_for('node.list'))

--- a/webapp/blaster/templates/conductor_list_nodes.html
+++ b/webapp/blaster/templates/conductor_list_nodes.html
@@ -2,7 +2,7 @@
 {% block body %}
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 <nav>
-  <h1>Conductors</h1>
+  <h1>Conductor: {{ conductor }}</h1>
   <table>
     <tr>
       <th>Router Name</th>

--- a/webapp/blaster/templates/node_list.html
+++ b/webapp/blaster/templates/node_list.html
@@ -29,5 +29,8 @@
     </tr>
 {%- endfor %}
   </table>
+  <form action="/node/fetch" method="post">
+    <input type="Submit" value="Fetch Quickstarts">
+  </form>
 </nav>
 {% endblock %}


### PR DESCRIPTION
Merging in functionality that adds a button to the nodes page to automatically search conductors for assets matching a device identifier and, if a matching asset-id is found, download the quickstart file and make a quickstart association to the node